### PR TITLE
Integrate Image Zoom on Blog Pages

### DIFF
--- a/src/components/MyMarkdownContent.astro
+++ b/src/components/MyMarkdownContent.astro
@@ -1,13 +1,8 @@
 ---
-import BlogMarkdownContent from 'starlight-blog/overrides/MarkdownContent.astro';
 import type { Props } from '@astrojs/starlight/props'
-import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro';
-import config from 'virtual:starlight-blog-config';
-
-const isBlogPost = Astro.props.slug.match(new RegExp(`^${config.prefix}/(?!(\\d+/?|tags/.+)$).+$`)) !== null
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
 ---
 
-{isBlogPost ? <ImageZoom /> : null}
-<BlogMarkdownContent {...Astro.props}>
-    <slot />
-</BlogMarkdownContent>
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I'm not sure if it was your decision to exclude the Image Zoom capabilities on Blog Pages, but it would be possible to merge the features...

To me it looks like you made the decision, so you can probably just Reject this Pull Request...

I wish you a happy day!